### PR TITLE
fix event mapping to reflect docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ function toWidget (proto) {
 
   const mappings = {}
   if (proto.attachedCallback) mappings.init = proto.attachedCallback
-  if (proto.detachedCallback) mappings.init = proto.detachedCallback
+  if (proto.detachedCallback) mappings.destroy = proto.detachedCallback
   if (proto.attributeChangedCallback) {
-    mappings.init = proto.attributeChangedCallback
+    mappings.update = proto.attributeChangedCallback
   }
 
   return virtualWidget(mappings)


### PR DESCRIPTION
reading through the docs and the source i noticed the mappings in the source didn't match the docs.

---

@yoshuawuyts 

regarding the module in general, i think it's a good idea to provide compatibility between virtual-dom and Web Components. yet personally i don't see Web Components, same with any Web standard, as being necessarily less framework-y than a pattern shared between modules (e.g. virtual-dom widgets), so i'm happy sticking with the patterns i enjoy.

as for your question about how to use this on the server, is there a specific use case you have in mind? i can't imagine another way other than providing a minimal DOM implementation in node, such as through `jsdom` or `min-document`, neither of which currently support custom elements as far as i'm aware.
